### PR TITLE
Add routing for individual pages

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,7 +1,17 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
-const routes: Routes = [];
+import { ReportsComponent } from './pages/reports/reports.component';
+import { TenderAwardsComponent } from './pages/tender-awards/tender-awards.component';
+import { CustomerListComponent } from './pages/customer-list/customer-list.component';
+
+const routes: Routes = [
+  { path: '', redirectTo: 'reports', pathMatch: 'full' },
+  { path: 'reports', component: ReportsComponent },
+  { path: 'tender-awards', component: TenderAwardsComponent },
+  { path: 'customers', component: CustomerListComponent },
+  { path: '**', redirectTo: 'reports' }
+];
 
 @NgModule({
   imports: [RouterModule.forRoot(routes)],

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -18,8 +18,8 @@
           mat-raised-button
           color="primary"
           class="view-button"
-          [disabled]="activeView === 'reports'"
-          (click)="selectView('reports')"
+          [routerLink]="['/reports']"
+          [disabled]="isRouteActive('/reports')"
         >
           Bidding Reports
         </button>
@@ -27,8 +27,8 @@
           mat-raised-button
           color="primary"
           class="view-button"
-          [disabled]="activeView === 'awards'"
-          (click)="selectView('awards')"
+          [routerLink]="['/tender-awards']"
+          [disabled]="isRouteActive('/tender-awards')"
         >
           Tender Awards
         </button>
@@ -36,13 +36,13 @@
           mat-raised-button
           color="primary"
           class="view-button"
-          [disabled]="activeView === 'customers'"
-          (click)="selectView('customers')"
+          [routerLink]="['/customers']"
+          [disabled]="isRouteActive('/customers')"
         >
           Customer List
         </button>
         <button
-          *ngIf="activeView === 'customers'"
+          *ngIf="isCustomersRoute"
           mat-stroked-button
           class="view-button"
           (click)="showSecretPopup = true"
@@ -53,13 +53,13 @@
       <div class="selectors">
         <mat-form-field appearance="outline" class="selector">
           <mat-label>Month</mat-label>
-          <mat-select [(ngModel)]="selectedMonth">
+          <mat-select [(ngModel)]="selectedMonth" (ngModelChange)="onFilterChange()">
             <mat-option *ngFor="let month of months" [value]="month">{{ month }}</mat-option>
           </mat-select>
         </mat-form-field>
         <mat-form-field appearance="outline" class="selector">
           <mat-label>Year</mat-label>
-          <mat-select [(ngModel)]="selectedYear">
+          <mat-select [(ngModel)]="selectedYear" (ngModelChange)="onFilterChange()">
             <mat-option *ngFor="let year of years" [value]="year">{{ year }}</mat-option>
           </mat-select>
         </mat-form-field>
@@ -68,23 +68,10 @@
   </mat-card>
 
   <section class="view-container">
-    <app-reports
-      *ngIf="activeView === 'reports'"
-      [selectedMonth]="selectedMonth"
-      [selectedYear]="selectedYear"
-    ></app-reports>
-
-    <app-tender-awards
-      *ngIf="activeView === 'awards'"
-      [selectedMonth]="selectedMonth"
-      [selectedYear]="selectedYear"
-    ></app-tender-awards>
-
-    <app-customer-list
-      *ngIf="activeView === 'customers'"
-      [selectedMonth]="selectedMonth"
-      [selectedYear]="selectedYear"
-    ></app-customer-list>
+    <router-outlet
+      (activate)="onRouteActivate($event)"
+      (deactivate)="onRouteDeactivate()"
+    ></router-outlet>
   </section>
 </main>
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,8 @@
-import { Component } from '@angular/core';
+import { Component, OnDestroy } from '@angular/core';
+import { IsActiveMatchOptions, NavigationEnd, Router } from '@angular/router';
+import { Subscription } from 'rxjs';
+import { filter } from 'rxjs/operators';
+
 import { SecretTableData } from './shared/interfaces';
 import { mockSecretTableData } from './shared/mock-data';
 
@@ -8,12 +12,21 @@ import { mockSecretTableData } from './shared/mock-data';
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css']
 })
-export class AppComponent {
+export class AppComponent implements OnDestroy {
   selectedMonth = 'September';
   selectedYear = '2024';
-  activeView: 'reports' | 'awards' | 'customers' = 'reports';
   showSecretPopup = false;
   isDarkTheme = false;
+  isCustomersRoute = false;
+
+  private activeRouteComponent: Record<string, unknown> | null = null;
+  private navigationSubscription: Subscription;
+  private readonly exactMatchOptions: IsActiveMatchOptions = {
+    paths: 'exact',
+    queryParams: 'ignored',
+    fragment: 'ignored',
+    matrixParams: 'ignored'
+  };
 
   months = [
     'January', 'February', 'March', 'April', 'May', 'June',
@@ -24,8 +37,15 @@ export class AppComponent {
 
   secretTableData: SecretTableData[] = mockSecretTableData;
 
-  selectView(view: 'reports' | 'awards' | 'customers'): void {
-    this.activeView = view;
+  constructor(private router: Router) {
+    this.navigationSubscription = this.router.events
+      .pipe(filter((event): event is NavigationEnd => event instanceof NavigationEnd))
+      .subscribe(event => {
+        this.updateRouteState(event.urlAfterRedirects);
+        this.updateActiveComponentInputs();
+      });
+
+    this.updateRouteState(this.router.url);
   }
 
   toggleTheme(): void {
@@ -34,6 +54,60 @@ export class AppComponent {
       document.documentElement.setAttribute('data-theme', 'dark');
     } else {
       document.documentElement.removeAttribute('data-theme');
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.navigationSubscription.unsubscribe();
+  }
+
+  onRouteActivate(component: Record<string, unknown>): void {
+    this.activeRouteComponent = component;
+    this.updateActiveComponentInputs();
+  }
+
+  onRouteDeactivate(): void {
+    this.activeRouteComponent = null;
+  }
+
+  onFilterChange(): void {
+    this.updateActiveComponentInputs();
+  }
+
+  isRouteActive(path: string): boolean {
+    return this.router.isActive(path, this.exactMatchOptions);
+  }
+
+  private updateRouteState(url: string): void {
+    this.isCustomersRoute = url.startsWith('/customers');
+    if (!this.isCustomersRoute) {
+      this.showSecretPopup = false;
+    }
+  }
+
+  private updateActiveComponentInputs(): void {
+    if (!this.activeRouteComponent) {
+      return;
+    }
+
+    this.assignIfPresent('selectedMonth', this.selectedMonth);
+    this.assignIfPresent('selectedYear', this.selectedYear);
+
+    this.callIfFunction('updateFiltersFromInput');
+    this.callIfFunction('loadData');
+  }
+
+  private assignIfPresent(key: 'selectedMonth' | 'selectedYear', value: string): void {
+    if (this.activeRouteComponent && key in this.activeRouteComponent) {
+      (this.activeRouteComponent as Record<string, string>)[key] = value;
+    }
+  }
+
+  private callIfFunction(methodName: 'updateFiltersFromInput' | 'loadData'): void {
+    const component = this.activeRouteComponent;
+    const method = component?.[methodName];
+    if (typeof method === 'function') {
+      method.call(component);
     }
   }
 }


### PR DESCRIPTION
## Summary
- define Angular routes for the reports, tender awards, and customer list pages
- update the application shell to use the router for navigation and route activation
- keep shared filters in sync with the active routed component while maintaining the existing secret popup

## Testing
- npm run lint *(fails: workspace has no lint target configured)*

------
https://chatgpt.com/codex/tasks/task_e_68d3a66c04cc832fa7d8a53cb99f0f88