### PR TITLE
Fix tab routing to avoid 404 errors

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -4,15 +4,12 @@ import { RouterModule, Routes } from '@angular/router';
 import { HomeComponent } from './pages/home/home.component';
 
 const routes: Routes = [
-  { path: '', redirectTo: 'reports', pathMatch: 'full' },
-  { path: 'reports', component: HomeComponent },
-  { path: 'tender-awards', component: HomeComponent },
-  { path: 'customers', component: HomeComponent },
-  { path: '**', redirectTo: 'reports' }
+  { path: '', component: HomeComponent },
+  { path: '**', redirectTo: '' }
 ];
 
 @NgModule({
-  imports: [RouterModule.forRoot(routes, { useHash: true })],
+  imports: [RouterModule.forRoot(routes)],
   exports: [RouterModule]
 })
 export class AppRoutingModule {}

--- a/src/app/components/app-shell/app-shell.component.html
+++ b/src/app/components/app-shell/app-shell.component.html
@@ -8,8 +8,8 @@
           color="primary"
           class="view-button"
           type="button"
-          [routerLink]="['/', tab.route]"
           [disabled]="activeTab === tab.id"
+          (click)="selectTab(tab.id)"
         >
           {{ tab.label }}
         </button>


### PR DESCRIPTION
## Summary
- serve the shell from the root route and remove hash-based redirects that caused the dev server to 404 on refresh
- manage tab selection through query parameters so navigation updates without requiring deep links

## Testing
- npx ng build --configuration development

------
https://chatgpt.com/codex/tasks/task_e_68d3f10b1d2c832f8e1cb257f264b1bb