### PR TITLE
Add dev configuration alias for Angular build

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -64,6 +64,11 @@
               "optimization": false,
               "extractLicenses": false,
               "sourceMap": true
+            },
+            "dev": {
+              "optimization": false,
+              "extractLicenses": false,
+              "sourceMap": true
             }
           },
           "defaultConfiguration": "production"
@@ -76,6 +81,9 @@
             },
             "development": {
               "buildTarget": "angulartest:build:development"
+            },
+            "dev": {
+              "buildTarget": "angulartest:build:dev"
             }
           },
           "defaultConfiguration": "development"
@@ -107,5 +115,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }


### PR DESCRIPTION
## Summary
- add a `dev` build configuration that mirrors the existing `development` settings
- wire the dev-server to use the new dev build target and disable Angular CLI analytics

## Testing
- npm run build -- --configuration dev

------
https://chatgpt.com/codex/tasks/task_e_68d549f9bbfc832f89cf8ae0f8e6ce8d