### PR TITLE
Revamp home toolbar and reports table styling

### DIFF
--- a/src/app/features/home/home-page/home-page.component.html
+++ b/src/app/features/home/home-page/home-page.component.html
@@ -1,43 +1,46 @@
 <main class="app-shell">
-  <mat-card class="material-card control-card">
-    <div class="control-header">
-      <div class="view-buttons" role="tablist">
-        <button
-          *ngFor="let tab of tabs"
-          mat-raised-button
-          color="primary"
-          class="view-button"
-          type="button"
-          [disabled]="activeTab === tab.id"
-          (click)="selectTab(tab.id)"
-        >
-          {{ tab.label }}
-        </button>
-        <button
-          *ngIf="activeTab === 'customers'"
-          mat-stroked-button
-          class="view-button"
-          type="button"
-          (click)="openSecretPopup()"
-        >
-          Customer Name Mapping
-        </button>
+  <mat-card class="material-card control-card" role="region" aria-label="Bidding platform toolbar">
+    <header class="control-toolbar">
+      <div class="toolbar-left">
+        <h1 class="toolbar-title">Bidding Platform</h1>
+        <div class="tab-row">
+          <nav class="tab-group" role="tablist" aria-label="Bidding views">
+            <button
+              *ngFor="let tab of tabs"
+              type="button"
+              class="tab-button"
+              [attr.aria-pressed]="activeTab === tab.id"
+              [class.tab-button--active]="activeTab === tab.id"
+              (click)="selectTab(tab.id)"
+            >
+              {{ tab.label }}
+            </button>
+          </nav>
+          <button
+            *ngIf="activeTab === 'customers'"
+            type="button"
+            class="mapping-button"
+            (click)="openSecretPopup()"
+          >
+            Customer Name Mapping
+          </button>
+        </div>
       </div>
-      <div class="selectors">
-        <mat-form-field appearance="outline" class="selector">
+      <div class="toolbar-filters">
+        <mat-form-field appearance="fill" class="selector">
           <mat-label>Month</mat-label>
           <mat-select [(ngModel)]="selectedMonth" (ngModelChange)="onMonthChange($event)">
             <mat-option *ngFor="let month of months" [value]="month">{{ month }}</mat-option>
           </mat-select>
         </mat-form-field>
-        <mat-form-field appearance="outline" class="selector">
+        <mat-form-field appearance="fill" class="selector">
           <mat-label>Year</mat-label>
           <mat-select [(ngModel)]="selectedYear" (ngModelChange)="onYearChange($event)">
             <mat-option *ngFor="let year of years" [value]="year">{{ year }}</mat-option>
           </mat-select>
         </mat-form-field>
       </div>
-    </div>
+    </header>
   </mat-card>
 
   <section class="view-container">

--- a/src/app/features/home/home-page/home-page.component.scss
+++ b/src/app/features/home/home-page/home-page.component.scss
@@ -3,44 +3,153 @@
   padding: 1.5rem 0;
 }
 
+
 .app-shell {
   display: grid;
-  gap: 1.5rem;
+  gap: 1.75rem;
 }
 
 .material-card {
-  border-radius: 0.75rem;
+  border-radius: 1.25rem;
 }
 
 .control-card {
-  .control-header {
+  padding: 1.75rem clamp(1.5rem, 2.5vw, 2.25rem);
+  background: linear-gradient(135deg, #f3f6ff 0%, #fdf6ff 55%, #f6fbff 100%);
+  box-shadow: 0 24px 60px -28px rgba(15, 23, 42, 0.55);
+  border: none;
+  color: #0f172a;
+
+  .control-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1.5rem;
+  }
+
+  .toolbar-left {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+  }
+
+  .toolbar-title {
+    margin: 0;
+    font-size: clamp(1.5rem, 1.5vw + 1rem, 2rem);
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    color: #1e293b;
+  }
+
+  .tab-row {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
     gap: 1rem;
-    justify-content: space-between;
   }
 
-  .view-buttons {
+  .tab-group {
     display: flex;
     flex-wrap: wrap;
     gap: 0.75rem;
   }
 
-  .view-button {
-    text-transform: none;
+  .tab-button {
+    padding: 0.45rem 1.6rem;
+    border-radius: 999px;
+    border: 1px solid rgba(30, 64, 175, 0.18);
+    background-color: rgba(59, 130, 246, 0.12);
+    color: #1d4ed8;
     font-weight: 600;
+    font-size: 0.95rem;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
+    transition: all 0.25s ease;
+    cursor: pointer;
   }
 
-  .selectors {
+  .tab-button:hover,
+  .tab-button:focus-visible {
+    outline: none;
+    border-color: rgba(59, 130, 246, 0.5);
+    box-shadow: 0 8px 18px -12px rgba(37, 99, 235, 0.75);
+  }
+
+  .tab-button--active {
+    background: linear-gradient(135deg, #2563eb 0%, #60a5fa 100%);
+    color: #ffffff;
+    border-color: transparent;
+    box-shadow: 0 16px 30px -18px rgba(37, 99, 235, 0.9);
+  }
+
+  .mapping-button {
+    padding: 0.45rem 1.4rem;
+    border-radius: 999px;
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    background: rgba(255, 255, 255, 0.85);
+    color: #0f172a;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    box-shadow: 0 12px 24px -18px rgba(15, 23, 42, 0.4);
+    transition: all 0.25s ease;
+    cursor: pointer;
+  }
+
+  .mapping-button:hover,
+  .mapping-button:focus-visible {
+    outline: none;
+    border-color: rgba(59, 130, 246, 0.45);
+    color: #1d4ed8;
+  }
+
+  .toolbar-filters {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.75rem;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 1rem;
   }
 
   .selector {
-    min-width: 160px;
+    min-width: 150px;
   }
+}
+
+:host ::ng-deep .control-card .selector.mat-mdc-form-field {
+  --mdc-filled-text-field-container-color: rgba(255, 255, 255, 0.82);
+  --mdc-filled-text-field-hover-container-color: rgba(255, 255, 255, 0.94);
+  --mdc-filled-text-field-focus-active-indicator-color: transparent;
+  --mdc-filled-text-field-active-indicator-color: transparent;
+  --mat-mdc-form-field-state-layer-color: transparent;
+  border-radius: 999px;
+}
+
+:host ::ng-deep .control-card .selector .mdc-text-field--filled {
+  border-radius: 999px;
+  box-shadow: 0 14px 34px -22px rgba(15, 23, 42, 0.65);
+}
+
+:host ::ng-deep .control-card .selector .mat-mdc-form-field-infix {
+  padding: 0.6rem 1.25rem 0.55rem 1.25rem;
+}
+
+:host ::ng-deep .control-card .selector .mdc-line-ripple {
+  display: none;
+}
+
+:host ::ng-deep .control-card .selector .mdc-floating-label {
+  color: rgba(30, 41, 59, 0.6);
+  font-weight: 500;
+}
+
+:host ::ng-deep .control-card .selector .mat-mdc-select-value-text,
+:host ::ng-deep .control-card .selector .mat-mdc-select-arrow {
+  color: #0f172a;
+  font-weight: 600;
+}
+
+:host ::ng-deep .control-card .selector .mat-mdc-select-trigger {
+  gap: 0.75rem;
 }
 
 .view-container {
@@ -96,16 +205,36 @@ th {
   font-weight: 600;
 }
 
-@media (max-width: 600px) {
+@media (max-width: 960px) {
   .control-card {
-    .control-header {
+    .control-toolbar {
       flex-direction: column;
       align-items: stretch;
     }
 
-    .selectors {
-      width: 100%;
+    .toolbar-filters {
       justify-content: flex-start;
+    }
+  }
+}
+
+@media (max-width: 600px) {
+  .control-card {
+    padding: 1.5rem;
+
+    .tab-row {
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    .tab-group {
+      width: 100%;
+    }
+
+    .tab-button,
+    .mapping-button {
+      width: 100%;
+      text-align: center;
     }
 
     .selector {

--- a/src/app/features/home/home-page/home-page.component.ts
+++ b/src/app/features/home/home-page/home-page.component.ts
@@ -24,9 +24,9 @@ interface SecretTableRow {
 })
 export class HomePageComponent implements OnInit, OnDestroy {
   readonly tabs: ToolbarTab[] = [
-    { id: 'reports', label: 'Reports' },
+    { id: 'reports', label: 'Bidding Reports' },
     { id: 'tender-awards', label: 'Tender Awards' },
-    { id: 'customers', label: 'Customers' }
+    { id: 'customers', label: 'Customer List' }
   ];
 
   readonly months: string[];

--- a/src/app/features/home/reports/reports.component.html
+++ b/src/app/features/home/reports/reports.component.html
@@ -1,106 +1,94 @@
 <mat-card class="material-card reports-card">
   <div class="table-container">
-    <table mat-table [dataSource]="reportsData" class="mat-elevation-z0 reports-table">
-      <ng-container matColumnDef="name">
-        <th mat-header-cell *matHeaderCellDef>
-          Name
-          <mat-icon>unfold_more</mat-icon>
-        </th>
-        <td mat-cell *matCellDef="let row">
-          <button mat-button class="link-button">{{ row.name }}</button>
-        </td>
-      </ng-container>
-
-      <ng-container matColumnDef="vl">
-        <th mat-header-cell *matHeaderCellDef>Total Bid Volume</th>
-        <td mat-cell *matCellDef="let row">{{ row.vl | number: '1.0-0' }}</td>
-      </ng-container>
-
-      <ng-container matColumnDef="vl2">
-        <th mat-header-cell *matHeaderCellDef>Volume</th>
-        <td mat-cell *matCellDef="let row">{{ row.vl2 | number: '1.0-0' }}</td>
-      </ng-container>
-
-      <ng-container matColumnDef="vibt">
-        <th mat-header-cell *matHeaderCellDef>Volume %</th>
-        <td mat-cell *matCellDef="let row">{{ row.vibt }}%</td>
-      </ng-container>
-
-      <ng-container matColumnDef="avg">
-        <th mat-header-cell *matHeaderCellDef>Weighted Avg PR</th>
-        <td mat-cell *matCellDef="let row">{{ row.avg | number: '1.2-2' }}</td>
-      </ng-container>
-
-      <ng-container matColumnDef="avgB">
-        <th mat-header-cell *matHeaderCellDef>Weighted Avg</th>
-        <td mat-cell *matCellDef="let row">{{ row.avgB | number: '1.2-2' }}</td>
-      </ng-container>
-
-      <ng-container matColumnDef="month">
-        <th mat-header-cell *matHeaderCellDef>Month</th>
-        <td mat-cell *matCellDef="let row">{{ row.month }}</td>
-      </ng-container>
-
-      <ng-container matColumnDef="year">
-        <th mat-header-cell *matHeaderCellDef>Year</th>
-        <td mat-cell *matCellDef="let row">{{ row.year }}</td>
-      </ng-container>
-
-      <ng-container matColumnDef="history">
-        <th mat-header-cell *matHeaderCellDef>History</th>
-        <td mat-cell *matCellDef="let row">
-          <div class="history-links">
-            <button mat-button class="link-button" *ngFor="let file of row.historyFiles">
-              {{ file }}
+    <table class="reports-table" role="table">
+      <thead>
+        <tr>
+          <th scope="col">
+            <div class="header-cell">
+              <span>Report Name</span>
+              <mat-icon aria-hidden="true">unfold_more</mat-icon>
+            </div>
+          </th>
+          <th scope="col">Total Bid Volume</th>
+          <th scope="col">Total Bid Volume PR</th>
+          <th scope="col">Total Bid Volume PP</th>
+          <th scope="col">Weighted Average PR</th>
+          <th scope="col">Weighted Average PP</th>
+          <th scope="col">Month</th>
+          <th scope="col">Year</th>
+          <th scope="col">Past History Analysis</th>
+          <th scope="col">Report</th>
+          <th scope="col">Status</th>
+          <th scope="col">Lock</th>
+          <th scope="col">Exception</th>
+          <th scope="col">Delete</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let row of reportsData">
+          <td data-label="Report Name">
+            <button type="button" mat-button class="link-button">{{ row.name }}</button>
+          </td>
+          <td data-label="Total Bid Volume">{{ row.totalBidVolume | number: '1.0-0' }}</td>
+          <td data-label="Total Bid Volume PR">{{ row.totalBidVolumePr | number: '1.0-0' }}</td>
+          <td data-label="Total Bid Volume PP">{{ row.totalBidVolumePp | number: '1.2-2' }}</td>
+          <td data-label="Weighted Average PR">{{ row.weightedAvgPr | number: '1.2-2' }}</td>
+          <td data-label="Weighted Average PP">{{ row.weightedAvgPp | number: '1.2-2' }}</td>
+          <td data-label="Month">{{ row.month }}</td>
+          <td data-label="Year">{{ row.year }}</td>
+          <td data-label="Past History Analysis">
+            <div class="history-links">
+              <button type="button" mat-button class="link-button" *ngFor="let file of row.historyFiles">
+                {{ file }}
+              </button>
+            </div>
+          </td>
+          <td data-label="Report">
+            <div class="report-actions">
+              <button
+                mat-icon-button
+                type="button"
+                class="report-action"
+                [attr.aria-label]="'Download ' + row.reportFile"
+              >
+                <mat-icon>file_download</mat-icon>
+              </button>
+              <button
+                mat-icon-button
+                type="button"
+                class="report-action"
+                [attr.aria-label]="'Preview ' + row.reportFile"
+              >
+                <mat-icon>description</mat-icon>
+              </button>
+            </div>
+          </td>
+          <td data-label="Status">
+            <span [ngClass]="statusClass(row.status)">{{ row.status }}</span>
+          </td>
+          <td data-label="Lock">
+            <button
+              mat-icon-button
+              type="button"
+              class="lock-button"
+              [class.lock-button--locked]="row.locked"
+              [attr.aria-label]="row.locked ? 'Unlock report' : 'Lock report'"
+            >
+              <mat-icon>{{ row.locked ? 'lock' : 'lock_open' }}</mat-icon>
             </button>
-          </div>
-        </td>
-      </ng-container>
-
-      <ng-container matColumnDef="report">
-        <th mat-header-cell *matHeaderCellDef>Report</th>
-        <td mat-cell *matCellDef="let row">
-          <button mat-icon-button color="primary">
-            <mat-icon>download</mat-icon>
-            <mat-icon>description</mat-icon>
-          </button>
-        </td>
-      </ng-container>
-
-      <ng-container matColumnDef="status">
-        <th mat-header-cell *matHeaderCellDef>Status</th>
-        <td mat-cell *matCellDef="let row">
-          <span [ngClass]="statusClass(row.status)">{{ row.status }}</span>
-        </td>
-      </ng-container>
-
-      <ng-container matColumnDef="locked">
-        <th mat-header-cell *matHeaderCellDef>Lock</th>
-        <td mat-cell *matCellDef="let row">
-          <button mat-icon-button [color]="row.locked ? 'warn' : undefined">
-            <mat-icon>lock</mat-icon>
-          </button>
-        </td>
-      </ng-container>
-
-      <ng-container matColumnDef="exception">
-        <th mat-header-cell *matHeaderCellDef>Exception</th>
-        <td mat-cell *matCellDef="let row">
-          <button mat-stroked-button color="accent">Add</button>
-        </td>
-      </ng-container>
-
-      <ng-container matColumnDef="delete">
-        <th mat-header-cell *matHeaderCellDef>Delete</th>
-        <td mat-cell *matCellDef="let row">
-          <button mat-icon-button color="warn">
-            <mat-icon>delete</mat-icon>
-          </button>
-        </td>
-      </ng-container>
-
-      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+          </td>
+          <td data-label="Exception">
+            <span [ngClass]="exceptionClass(row.exception)">
+              {{ row.exception ? 'Exception' : 'None' }}
+            </span>
+          </td>
+          <td data-label="Delete">
+            <button mat-icon-button type="button" class="delete-button" aria-label="Delete report">
+              <mat-icon>delete_outline</mat-icon>
+            </button>
+          </td>
+        </tr>
+      </tbody>
     </table>
   </div>
 

--- a/src/app/features/home/reports/reports.component.scss
+++ b/src/app/features/home/reports/reports.component.scss
@@ -1,49 +1,192 @@
 .reports-card {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.5rem;
+  padding: 1.75rem clamp(1.5rem, 2vw, 2.25rem);
+  border: none;
+  border-radius: 1.25rem;
+  background: linear-gradient(140deg, #eef2ff 0%, #fdf2f8 100%);
+  box-shadow: 0 26px 60px -32px rgba(15, 23, 42, 0.5);
 }
 
 .table-container {
-  overflow: auto;
+  overflow-x: auto;
+  border-radius: 1.25rem;
+  background: rgba(255, 255, 255, 0.95);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35);
 }
 
 .reports-table {
   width: 100%;
+  min-width: 960px;
+  border-collapse: collapse;
+  border-radius: 1.25rem;
+  overflow: hidden;
+}
+
+.reports-table thead {
+  background: linear-gradient(135deg, #e2e8ff 0%, #dff4ff 100%);
+  color: #0f172a;
+  text-transform: none;
+}
+
+.reports-table th,
+.reports-table td {
+  padding: 1rem 1.25rem;
+  text-align: left;
+  font-size: 0.95rem;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.06);
+}
+
+.reports-table th {
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.reports-table tbody tr:last-of-type td {
+  border-bottom: none;
+}
+
+.reports-table tbody tr:hover {
+  background: rgba(226, 232, 255, 0.35);
+}
+
+.header-cell {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.header-cell mat-icon {
+  font-size: 18px;
+  height: 18px;
+  width: 18px;
+  color: rgba(51, 65, 85, 0.65);
 }
 
 .history-links {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.25rem;
+  flex-direction: column;
+  gap: 0.35rem;
 }
 
 .link-button {
   padding: 0;
+  min-width: 0;
+  justify-content: flex-start;
+  font-weight: 600;
+  color: #1d4ed8;
+  letter-spacing: -0.01em;
+}
+
+.link-button:hover,
+.link-button:focus-visible {
+  background: transparent;
+  text-decoration: underline;
+}
+
+.report-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+:host ::ng-deep .report-action.mat-mdc-icon-button,
+:host ::ng-deep .lock-button.mat-mdc-icon-button,
+:host ::ng-deep .delete-button.mat-mdc-icon-button {
+  --mdc-icon-button-state-layer-size: 40px;
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+:host ::ng-deep .report-action.mat-mdc-icon-button {
+  background: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+}
+
+:host ::ng-deep .report-action.mat-mdc-icon-button:hover {
+  background: rgba(37, 99, 235, 0.22);
+}
+
+:host ::ng-deep .lock-button.mat-mdc-icon-button {
+  background: rgba(148, 163, 184, 0.18);
+  color: #475569;
+}
+
+:host ::ng-deep .lock-button.mat-mdc-icon-button.lock-button--locked {
+  background: rgba(248, 113, 113, 0.18);
+  color: #b91c1c;
+}
+
+:host ::ng-deep .delete-button.mat-mdc-icon-button {
+  background: rgba(239, 68, 68, 0.12);
+  color: #b91c1c;
+}
+
+.status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.85rem;
+  letter-spacing: -0.01em;
+}
+
+.status--active {
+  background: rgba(34, 197, 94, 0.18);
+  color: #047857;
+}
+
+.status--pending {
+  background: rgba(250, 204, 21, 0.22);
+  color: #b45309;
+}
+
+.status--complete {
+  background: rgba(59, 130, 246, 0.18);
+  color: #1d4ed8;
+}
+
+.exception-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.18);
+  color: #475569;
+  font-weight: 600;
+  font-size: 0.85rem;
+  letter-spacing: -0.01em;
+}
+
+.exception-chip--active {
+  background: rgba(248, 113, 113, 0.22);
+  color: #b91c1c;
 }
 
 .reports-footer {
   font-size: 0.875rem;
-  color: rgba(0, 0, 0, 0.6);
+  color: rgba(15, 23, 42, 0.65);
+  text-align: right;
 }
 
-.status {
-  padding: 0.125rem 0.5rem;
-  border-radius: 12px;
-  font-weight: 600;
+@media (max-width: 900px) {
+  .reports-footer {
+    text-align: left;
+  }
 }
 
-.status--active {
-  background-color: rgba(16, 185, 129, 0.12);
-  color: #047857;
-}
+@media (max-width: 720px) {
+  .reports-card {
+    padding: 1.5rem;
+  }
 
-.status--draft {
-  background-color: rgba(59, 130, 246, 0.12);
-  color: rgb(0, 157, 208);
-}
-
-.status--complete {
-  background-color: rgba(107, 114, 128, 0.12);
-  color: #374151;
+  .reports-table {
+    min-width: 720px;
+  }
 }

--- a/src/app/features/home/reports/reports.component.ts
+++ b/src/app/features/home/reports/reports.component.ts
@@ -5,16 +5,18 @@ import { HomeFiltersService } from '../services/home-filters.service';
 
 interface ReportsRow {
   name: string;
-  vl: number;
-  vl2: number;
-  vibt: number;
-  avg: number;
-  avgB: number;
+  totalBidVolume: number;
+  totalBidVolumePr: number;
+  totalBidVolumePp: number;
+  weightedAvgPr: number;
+  weightedAvgPp: number;
   month: string;
   year: number;
   historyFiles: string[];
-  status: 'Active' | 'Draft' | 'Complete';
+  reportFile: string;
+  status: 'Active' | 'Pending' | 'Complete';
   locked: boolean;
+  exception: boolean;
 }
 
 @Component({
@@ -24,62 +26,96 @@ interface ReportsRow {
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ReportsComponent implements OnDestroy {
-  readonly displayedColumns: string[] = [
-    'name',
-    'vl',
-    'vl2',
-    'vibt',
-    'avg',
-    'avgB',
-    'month',
-    'year',
-    'history',
-    'report',
-    'status',
-    'locked',
-    'exception',
-    'delete'
-  ];
-
   readonly reportsData: ReportsRow[] = [
     {
-      name: 'Monthly Awards Overview',
-      vl: 1250,
-      vl2: 980,
-      vibt: 74,
-      avg: 1.24,
-      avgB: 1.12,
+      name: 'RoK LPG Tender Awards Analysis January 2020',
+      totalBidVolume: 10360,
+      totalBidVolumePr: 5203,
+      totalBidVolumePp: 18.17,
+      weightedAvgPr: 0.94,
+      weightedAvgPp: 17.35,
       month: 'January',
-      year: 2024,
-      historyFiles: ['Overview.pdf', 'Monthly-Notes.docx'],
-      status: 'Active',
-      locked: false
+      year: 2020,
+      historyFiles: ['history_001.pdf', 'log_001.txt'],
+      reportFile: 'report_001.pdf',
+      status: 'Pending',
+      locked: false,
+      exception: true
     },
     {
-      name: 'Bidder Trend Summary',
-      vl: 980,
-      vl2: 860,
-      vibt: 67,
-      avg: 1.17,
-      avgB: 1.03,
-      month: 'February',
-      year: 2024,
-      historyFiles: ['Summary.xlsx'],
-      status: 'Draft',
-      locked: true
-    },
-    {
-      name: 'Regional Breakdown',
-      vl: 1430,
-      vl2: 1205,
-      vibt: 81,
-      avg: 1.31,
-      avgB: 1.2,
+      name: 'RoK LPG Tender Awards Analysis March 2020',
+      totalBidVolume: 12080,
+      totalBidVolumePr: 6640,
+      totalBidVolumePp: 19.64,
+      weightedAvgPr: 1.06,
+      weightedAvgPp: 18.42,
       month: 'March',
-      year: 2023,
-      historyFiles: ['Exports.csv', 'Archive.pdf'],
+      year: 2020,
+      historyFiles: ['history_002.pdf', 'notes_003.docx'],
+      reportFile: 'report_002.pdf',
       status: 'Complete',
-      locked: false
+      locked: true,
+      exception: false
+    },
+    {
+      name: 'RoK LPG Tender Awards Analysis October 2022',
+      totalBidVolume: 9870,
+      totalBidVolumePr: 5480,
+      totalBidVolumePp: 17.08,
+      weightedAvgPr: 0.89,
+      weightedAvgPp: 16.74,
+      month: 'October',
+      year: 2022,
+      historyFiles: ['history_003.pdf', 'log_004.txt'],
+      reportFile: 'report_003.pdf',
+      status: 'Active',
+      locked: false,
+      exception: true
+    },
+    {
+      name: 'RoK LPG Tender Awards Analysis November 2022',
+      totalBidVolume: 9745,
+      totalBidVolumePr: 5342,
+      totalBidVolumePp: 16.88,
+      weightedAvgPr: 0.92,
+      weightedAvgPp: 16.09,
+      month: 'November',
+      year: 2022,
+      historyFiles: ['history_004.pdf', 'log_005.txt'],
+      reportFile: 'report_004.pdf',
+      status: 'Pending',
+      locked: true,
+      exception: false
+    },
+    {
+      name: 'RoK LPG Tender Awards Analysis December 2022',
+      totalBidVolume: 11030,
+      totalBidVolumePr: 6021,
+      totalBidVolumePp: 18.92,
+      weightedAvgPr: 1.04,
+      weightedAvgPp: 17.86,
+      month: 'December',
+      year: 2022,
+      historyFiles: ['history_005.pdf', 'notes_006.docx'],
+      reportFile: 'report_005.pdf',
+      status: 'Complete',
+      locked: false,
+      exception: true
+    },
+    {
+      name: 'RoK LPG Tender Awards Analysis January 2023',
+      totalBidVolume: 12560,
+      totalBidVolumePr: 7125,
+      totalBidVolumePp: 19.74,
+      weightedAvgPr: 1.12,
+      weightedAvgPp: 18.65,
+      month: 'January',
+      year: 2023,
+      historyFiles: ['history_006.pdf', 'log_007.txt'],
+      reportFile: 'report_006.pdf',
+      status: 'Complete',
+      locked: true,
+      exception: false
     }
   ];
 
@@ -109,12 +145,16 @@ export class ReportsComponent implements OnDestroy {
     switch (status) {
       case 'Active':
         return 'status status--active';
-      case 'Draft':
-        return 'status status--draft';
+      case 'Pending':
+        return 'status status--pending';
       case 'Complete':
         return 'status status--complete';
       default:
         return 'status';
     }
+  }
+
+  exceptionClass(hasException: ReportsRow['exception']): string {
+    return hasException ? 'exception-chip exception-chip--active' : 'exception-chip';
   }
 }


### PR DESCRIPTION
## Summary
- restyled the home page toolbar with gradient card, pill tabs, and redesigned selectors to match the provided design
- rebuilt the bidding reports markup and sample data to reflect the screenshot table layout with history links, actions, and badges
- refreshed status and exception styling for the reports table to align with the visual design cues

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6841e0d78832f83c87bcbb8b8df6e