### PR TITLE
Refresh customer list layout and centralize shared styles

### DIFF
--- a/src/app/features/home/customer-list/customer-list.component.html
+++ b/src/app/features/home/customer-list/customer-list.component.html
@@ -1,109 +1,181 @@
-<mat-card class="material-card list-controls">
-  <div class="export-row">
-    <button mat-raised-button color="accent">
-      <mat-icon>table_view</mat-icon>
+<mat-card class="material-card list-controls" role="region" aria-label="Customer list filters">
+  <div class="list-toolbar">
+    <div class="segment-group" role="tablist" aria-label="Product selection">
+      <button
+        *ngFor="let segment of productSegments"
+        type="button"
+        class="segment-button"
+        [attr.aria-pressed]="activeProductSegment === segment.id"
+        [class.segment-button--active]="activeProductSegment === segment.id"
+        (click)="selectProductSegment(segment.id)"
+      >
+        {{ segment.label }}
+      </button>
+    </div>
+    <button mat-raised-button type="button" class="export-button">
+      <mat-icon>file_download</mat-icon>
       Export to Excel
     </button>
   </div>
 
-  <div class="filters">
-    <div class="filter-group">
-      <mat-form-field appearance="outline">
-        <mat-label>Multiple Bidders</mat-label>
-        <mat-select
-          [(ngModel)]="listFilters.multipleCustomers"
-          (selectionChange)="updateListFilter('multipleCustomers', $event.value)"
-        >
-          <mat-option value="">All</mat-option>
-          <mat-option value="customer1">Bidder 1</mat-option>
-          <mat-option value="customer2">Bidder 2</mat-option>
-          <mat-option value="customer3">Bidder 3</mat-option>
-        </mat-select>
-      </mat-form-field>
-      <button mat-icon-button (click)="resetListFilter('multipleCustomers')">
-        <mat-icon>replay</mat-icon>
+  <div class="filters-grid">
+    <mat-form-field appearance="fill" class="filter-field">
+      <mat-label>Multiple Bidders</mat-label>
+      <mat-icon matPrefix>groups</mat-icon>
+      <mat-select
+        [(ngModel)]="listFilters.multipleCustomers"
+        (selectionChange)="updateListFilter('multipleCustomers', $event.value)"
+      >
+        <mat-option value="">All</mat-option>
+        <mat-option value="customer1">Bidder 1</mat-option>
+        <mat-option value="customer2">Bidder 2</mat-option>
+        <mat-option value="customer3">Bidder 3</mat-option>
+      </mat-select>
+      <button
+        *ngIf="listFilters.multipleCustomers"
+        mat-icon-button
+        type="button"
+        matSuffix
+        (click)="resetListFilter('multipleCustomers')"
+        aria-label="Reset multiple bidders filter"
+      >
+        <mat-icon>close</mat-icon>
       </button>
-    </div>
+    </mat-form-field>
 
-    <div class="filter-group">
-      <mat-form-field appearance="outline">
-        <mat-label>Bidder</mat-label>
-        <mat-select [(ngModel)]="listFilters.customer" (selectionChange)="updateListFilter('customer', $event.value)">
-          <mat-option value="">All bidders</mat-option>
-          <mat-option value="john">Ken Parker</mat-option>
-          <mat-option value="jane">Jane Smith</mat-option>
-          <mat-option value="bob">Bob Johnson</mat-option>
-        </mat-select>
-      </mat-form-field>
-      <button mat-icon-button (click)="resetListFilter('customer')">
-        <mat-icon>replay</mat-icon>
+    <mat-form-field appearance="fill" class="filter-field">
+      <mat-label>Bidder</mat-label>
+      <mat-icon matPrefix>person</mat-icon>
+      <mat-select [(ngModel)]="listFilters.customer" (selectionChange)="updateListFilter('customer', $event.value)">
+        <mat-option value="">All bidders</mat-option>
+        <mat-option value="john">Ken Parker</mat-option>
+        <mat-option value="jane">Jane Smith</mat-option>
+        <mat-option value="bob">Bob Johnson</mat-option>
+      </mat-select>
+      <button
+        *ngIf="listFilters.customer"
+        mat-icon-button
+        type="button"
+        matSuffix
+        (click)="resetListFilter('customer')"
+        aria-label="Reset bidder filter"
+      >
+        <mat-icon>close</mat-icon>
       </button>
-    </div>
+    </mat-form-field>
 
-    <div class="filter-group">
-      <mat-form-field appearance="outline">
-        <mat-label>Status</mat-label>
-        <mat-select [(ngModel)]="listFilters.status" (selectionChange)="updateListFilter('status', $event.value)">
-          <mat-option value="">All statuses</mat-option>
-          <mat-option value="active">Active</mat-option>
-          <mat-option value="pending">Pending</mat-option>
-          <mat-option value="complete">Complete</mat-option>
-        </mat-select>
-      </mat-form-field>
-      <button mat-icon-button (click)="resetListFilter('status')">
-        <mat-icon>replay</mat-icon>
+    <mat-form-field appearance="fill" class="filter-field">
+      <mat-label>Status</mat-label>
+      <mat-icon matPrefix>check_circle</mat-icon>
+      <mat-select [(ngModel)]="listFilters.status" (selectionChange)="updateListFilter('status', $event.value)">
+        <mat-option value="">All statuses</mat-option>
+        <mat-option value="active">Active</mat-option>
+        <mat-option value="pending">Pending</mat-option>
+        <mat-option value="complete">Complete</mat-option>
+      </mat-select>
+      <button
+        *ngIf="listFilters.status"
+        mat-icon-button
+        type="button"
+        matSuffix
+        (click)="resetListFilter('status')"
+        aria-label="Reset status filter"
+      >
+        <mat-icon>close</mat-icon>
       </button>
-    </div>
+    </mat-form-field>
 
-    <div class="filter-group">
-      <mat-form-field appearance="outline">
-        <mat-label>Month</mat-label>
-        <mat-select [(ngModel)]="listFilters.month" (selectionChange)="updateListFilter('month', $event.value)">
-          <mat-option value="">All months</mat-option>
-          <mat-option *ngFor="let month of months" [value]="month.toLowerCase()">
-            {{ month }}
-          </mat-option>
-        </mat-select>
-      </mat-form-field>
-      <button mat-icon-button (click)="resetListFilter('month')">
-        <mat-icon>replay</mat-icon>
+    <mat-form-field appearance="fill" class="filter-field">
+      <mat-label>Month</mat-label>
+      <mat-icon matPrefix>event</mat-icon>
+      <mat-select [(ngModel)]="listFilters.month" (selectionChange)="updateListFilter('month', $event.value)">
+        <mat-option value="">All months</mat-option>
+        <mat-option *ngFor="let month of months" [value]="month.toLowerCase()">{{ month }}</mat-option>
+      </mat-select>
+      <button
+        *ngIf="listFilters.month"
+        mat-icon-button
+        type="button"
+        matSuffix
+        (click)="resetListFilter('month')"
+        aria-label="Reset month filter"
+      >
+        <mat-icon>close</mat-icon>
       </button>
-    </div>
+    </mat-form-field>
 
-    <div class="filter-group">
-      <mat-form-field appearance="outline">
-        <mat-label>Year</mat-label>
-        <mat-select [(ngModel)]="listFilters.year" (selectionChange)="updateListFilter('year', $event.value)">
-          <mat-option value="">All years</mat-option>
-          <mat-option *ngFor="let year of years" [value]="year">{{ year }}</mat-option>
-        </mat-select>
-      </mat-form-field>
-      <button mat-icon-button (click)="resetListFilter('year')">
-        <mat-icon>replay</mat-icon>
+    <mat-form-field appearance="fill" class="filter-field">
+      <mat-label>Year</mat-label>
+      <mat-icon matPrefix>calendar_month</mat-icon>
+      <mat-select [(ngModel)]="listFilters.year" (selectionChange)="updateListFilter('year', $event.value)">
+        <mat-option value="">All years</mat-option>
+        <mat-option *ngFor="let year of years" [value]="year">{{ year }}</mat-option>
+      </mat-select>
+      <button
+        *ngIf="listFilters.year"
+        mat-icon-button
+        type="button"
+        matSuffix
+        (click)="resetListFilter('year')"
+        aria-label="Reset year filter"
+      >
+        <mat-icon>close</mat-icon>
       </button>
-    </div>
+    </mat-form-field>
 
-    <div class="filter-group">
-      <mat-form-field appearance="outline" class="range-field">
-        <mat-label>RLF Range From</mat-label>
-        <input matInput [(ngModel)]="listFilters.rangeFrom" (ngModelChange)="updateListFilter('rangeFrom', $event)" />
-      </mat-form-field>
-      <mat-form-field appearance="outline" class="range-field">
-        <mat-label>RLF Range To</mat-label>
-        <input matInput [(ngModel)]="listFilters.rangeTo" (ngModelChange)="updateListFilter('rangeTo', $event)" />
-      </mat-form-field>
-      <button mat-icon-button (click)="resetListFilter('rangeFrom'); resetListFilter('rangeTo')">
-        <mat-icon>replay</mat-icon>
+    <mat-form-field appearance="fill" class="filter-field range-field">
+      <mat-label>RLF Range From</mat-label>
+      <mat-icon matPrefix>straighten</mat-icon>
+      <input
+        matInput
+        type="text"
+        inputmode="decimal"
+        [(ngModel)]="listFilters.rangeFrom"
+        (ngModelChange)="updateListFilter('rangeFrom', $event)"
+        placeholder="0"
+      />
+      <button
+        *ngIf="listFilters.rangeFrom"
+        mat-icon-button
+        type="button"
+        matSuffix
+        (click)="resetListFilter('rangeFrom')"
+        aria-label="Reset RLF range from filter"
+      >
+        <mat-icon>close</mat-icon>
       </button>
-    </div>
+    </mat-form-field>
+
+    <mat-form-field appearance="fill" class="filter-field range-field">
+      <mat-label>RLF Range To</mat-label>
+      <mat-icon matPrefix>straighten</mat-icon>
+      <input
+        matInput
+        type="text"
+        inputmode="decimal"
+        [(ngModel)]="listFilters.rangeTo"
+        (ngModelChange)="updateListFilter('rangeTo', $event)"
+        placeholder="0"
+      />
+      <button
+        *ngIf="listFilters.rangeTo"
+        mat-icon-button
+        type="button"
+        matSuffix
+        (click)="resetListFilter('rangeTo')"
+        aria-label="Reset RLF range to filter"
+      >
+        <mat-icon>close</mat-icon>
+      </button>
+    </mat-form-field>
   </div>
 </mat-card>
 
-<mat-card class="material-card list-card">
+<mat-card class="material-card list-card" role="region" aria-label="Customer list table">
   <div class="table-container">
     <table mat-table [dataSource]="listTableData" class="mat-elevation-z0">
       <ng-container *ngFor="let column of columns" [matColumnDef]="column.key">
-        <th mat-header-cell *matHeaderCellDef>{{ column.label }}</th>
+        <th mat-header-cell *matHeaderCellDef scope="col">{{ column.label }}</th>
         <td mat-cell *matCellDef="let row">{{ valueFor(row, column.key) }}</td>
       </ng-container>
 

--- a/src/app/features/home/customer-list/customer-list.component.scss
+++ b/src/app/features/home/customer-list/customer-list.component.scss
@@ -1,33 +1,179 @@
+:host {
+  display: block;
+}
+
 .list-controls {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
+  display: grid;
+  gap: 1.5rem;
+  padding: 1.75rem clamp(1.5rem, 2vw, 2.25rem);
+  background: linear-gradient(135deg, #f8fbff 0%, #fdf7ff 60%, #f2f9ff 100%);
 }
 
-.export-row {
+.list-toolbar {
   display: flex;
-  justify-content: flex-end;
-}
-
-.filters {
-  display: flex;
-  gap: 1rem;
-}
-
-.filter-group {
-  display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  gap: 0.5rem;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.segment-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.segment-button {
+  padding: 0.4rem 1.4rem;
+  border-radius: 999px;
+  border: 1px solid rgba(59, 130, 246, 0.25);
+  background: rgba(59, 130, 246, 0.08);
+  color: #2563eb;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  transition: all 0.25s ease;
+  cursor: pointer;
+}
+
+.segment-button:hover,
+.segment-button:focus-visible {
+  outline: none;
+  border-color: rgba(59, 130, 246, 0.5);
+  box-shadow: 0 12px 24px -18px rgba(37, 99, 235, 0.75);
+}
+
+.segment-button--active {
+  background: linear-gradient(135deg, #2563eb 0%, #60a5fa 100%);
+  color: #ffffff;
+  border-color: transparent;
+  box-shadow: 0 18px 36px -22px rgba(37, 99, 235, 0.9);
+}
+
+.export-button {
+  --mdc-elevated-button-container-color: transparent;
+  --mdc-elevated-button-label-text-color: currentColor;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.6rem 1.65rem;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  background: linear-gradient(135deg, #22c55e 0%, #16a34a 100%);
+  color: #ffffff;
+  box-shadow: 0 24px 40px -24px rgba(34, 197, 94, 0.75);
+  transition: filter 0.2s ease;
+}
+
+.export-button:hover,
+.export-button:focus-visible {
+  filter: brightness(1.05);
+}
+
+.export-button mat-icon {
+  font-size: 1.25rem;
+}
+
+.filters-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.list-controls .filter-field.mat-mdc-form-field {
+  --mdc-filled-text-field-container-color: rgba(255, 255, 255, 0.95);
+  --mdc-filled-text-field-hover-container-color: #ffffff;
+}
+
+.list-controls .filter-field {
+  .mdc-text-field--filled {
+    box-shadow: 0 20px 40px -28px rgba(15, 23, 42, 0.45);
+  }
+
+  mat-icon[matPrefix] {
+    color: rgba(37, 99, 235, 0.65);
+  }
+
+  .mat-mdc-icon-button {
+    --mdc-icon-button-icon-color: rgba(100, 116, 139, 0.9);
+  }
 }
 
 .range-field {
-  width: 8rem;
+  max-width: 200px;
+}
+
+.list-card {
+  padding: clamp(1.5rem, 2vw, 2.25rem);
+  background: rgba(255, 255, 255, 0.92);
 }
 
 .list-card .table-container {
-  overflow: auto;
+  border-radius: calc(var(--app-card-radius) - 0.35rem);
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.12);
 }
 
-.table-container table {
+.list-card table {
   width: 100%;
+  border-collapse: collapse;
+}
+
+.list-card th {
+  background: linear-gradient(90deg, #ecf1ff 0%, #f7faff 100%);
+  color: #1f2a44;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  padding: 0.9rem 1.1rem;
+  text-transform: none;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.list-card td {
+  padding: 0.9rem 1.1rem;
+  color: #1f2937;
+  font-weight: 500;
+  background: rgba(255, 255, 255, 0.88);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.list-card tr.mat-mdc-row:nth-child(even) td {
+  background: rgba(239, 246, 255, 0.88);
+}
+
+.list-card tr.mat-mdc-row:hover td {
+  background: rgba(219, 234, 254, 0.9);
+}
+
+.list-card tr:last-of-type td {
+  border-bottom: none;
+}
+
+@media (max-width: 960px) {
+  .list-toolbar {
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 720px) {
+  .filters-grid {
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  }
+
+  .range-field {
+    max-width: none;
+  }
+}
+
+@media (max-width: 600px) {
+  .list-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .segment-button,
+  .export-button {
+    width: 100%;
+    text-align: center;
+  }
 }

--- a/src/app/features/home/customer-list/customer-list.component.ts
+++ b/src/app/features/home/customer-list/customer-list.component.ts
@@ -26,6 +26,8 @@ interface CustomerListFilters {
   rangeTo: string;
 }
 
+type ProductSegment = 'all' | 'propane' | 'butane';
+
 @Component({
   selector: 'app-customer-list',
   templateUrl: './customer-list.component.html',
@@ -33,6 +35,14 @@ interface CustomerListFilters {
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CustomerListComponent implements OnDestroy {
+  readonly productSegments: ReadonlyArray<{ id: ProductSegment; label: string }> = [
+    { id: 'all', label: 'All' },
+    { id: 'propane', label: 'Propane' },
+    { id: 'butane', label: 'Butane' }
+  ];
+
+  activeProductSegment: ProductSegment = 'all';
+
   readonly columns: CustomerListColumn[] = [
     { key: 'bidder', label: 'Bidder' },
     { key: 'region', label: 'Region' },
@@ -111,6 +121,10 @@ export class CustomerListComponent implements OnDestroy {
 
   resetListFilter<Key extends keyof CustomerListFilters>(key: Key): void {
     this.listFilters[key] = '' as CustomerListFilters[Key];
+  }
+
+  selectProductSegment(segment: ProductSegment): void {
+    this.activeProductSegment = segment;
   }
 
   valueFor(row: CustomerListRow, key: keyof CustomerListRow): string | number {

--- a/src/app/features/home/home-page/home-page.component.scss
+++ b/src/app/features/home/home-page/home-page.component.scss
@@ -1,161 +1,3 @@
-:host {
-  display: block;
-  padding: 1.5rem 0;
-}
-
-
-.app-shell {
-  display: grid;
-  gap: 1.75rem;
-}
-
-.material-card {
-  border-radius: 1.25rem;
-}
-
-.control-card {
-  padding: 1.75rem clamp(1.5rem, 2.5vw, 2.25rem);
-  background: linear-gradient(135deg, #f3f6ff 0%, #fdf6ff 55%, #f6fbff 100%);
-  box-shadow: 0 24px 60px -28px rgba(15, 23, 42, 0.55);
-  border: none;
-  color: #0f172a;
-
-  .control-toolbar {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    align-items: flex-start;
-    gap: 1.5rem;
-  }
-
-  .toolbar-left {
-    display: flex;
-    flex-direction: column;
-    gap: 1.25rem;
-  }
-
-  .toolbar-title {
-    margin: 0;
-    font-size: clamp(1.5rem, 1.5vw + 1rem, 2rem);
-    font-weight: 700;
-    letter-spacing: -0.02em;
-    color: #1e293b;
-  }
-
-  .tab-row {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 1rem;
-  }
-
-  .tab-group {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.75rem;
-  }
-
-  .tab-button {
-    padding: 0.45rem 1.6rem;
-    border-radius: 999px;
-    border: 1px solid rgba(30, 64, 175, 0.18);
-    background-color: rgba(59, 130, 246, 0.12);
-    color: #1d4ed8;
-    font-weight: 600;
-    font-size: 0.95rem;
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
-    transition: all 0.25s ease;
-    cursor: pointer;
-  }
-
-  .tab-button:hover,
-  .tab-button:focus-visible {
-    outline: none;
-    border-color: rgba(59, 130, 246, 0.5);
-    box-shadow: 0 8px 18px -12px rgba(37, 99, 235, 0.75);
-  }
-
-  .tab-button--active {
-    background: linear-gradient(135deg, #2563eb 0%, #60a5fa 100%);
-    color: #ffffff;
-    border-color: transparent;
-    box-shadow: 0 16px 30px -18px rgba(37, 99, 235, 0.9);
-  }
-
-  .mapping-button {
-    padding: 0.45rem 1.4rem;
-    border-radius: 999px;
-    border: 1px solid rgba(148, 163, 184, 0.4);
-    background: rgba(255, 255, 255, 0.85);
-    color: #0f172a;
-    font-weight: 600;
-    letter-spacing: -0.01em;
-    box-shadow: 0 12px 24px -18px rgba(15, 23, 42, 0.4);
-    transition: all 0.25s ease;
-    cursor: pointer;
-  }
-
-  .mapping-button:hover,
-  .mapping-button:focus-visible {
-    outline: none;
-    border-color: rgba(59, 130, 246, 0.45);
-    color: #1d4ed8;
-  }
-
-  .toolbar-filters {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: flex-end;
-    align-items: center;
-    gap: 1rem;
-  }
-
-  .selector {
-    min-width: 150px;
-  }
-}
-
-:host ::ng-deep .control-card .selector.mat-mdc-form-field {
-  --mdc-filled-text-field-container-color: rgba(255, 255, 255, 0.82);
-  --mdc-filled-text-field-hover-container-color: rgba(255, 255, 255, 0.94);
-  --mdc-filled-text-field-focus-active-indicator-color: transparent;
-  --mdc-filled-text-field-active-indicator-color: transparent;
-  --mat-mdc-form-field-state-layer-color: transparent;
-  border-radius: 999px;
-}
-
-:host ::ng-deep .control-card .selector .mdc-text-field--filled {
-  border-radius: 999px;
-  box-shadow: 0 14px 34px -22px rgba(15, 23, 42, 0.65);
-}
-
-:host ::ng-deep .control-card .selector .mat-mdc-form-field-infix {
-  padding: 0.6rem 1.25rem 0.55rem 1.25rem;
-}
-
-:host ::ng-deep .control-card .selector .mdc-line-ripple {
-  display: none;
-}
-
-:host ::ng-deep .control-card .selector .mdc-floating-label {
-  color: rgba(30, 41, 59, 0.6);
-  font-weight: 500;
-}
-
-:host ::ng-deep .control-card .selector .mat-mdc-select-value-text,
-:host ::ng-deep .control-card .selector .mat-mdc-select-arrow {
-  color: #0f172a;
-  font-weight: 600;
-}
-
-:host ::ng-deep .control-card .selector .mat-mdc-select-trigger {
-  gap: 0.75rem;
-}
-
-.view-container {
-  min-height: 320px;
-}
-
 .secret-dialog {
   position: fixed;
   inset: 0;
@@ -168,6 +10,10 @@
 
 .secret-card {
   width: min(640px, 100%);
+}
+
+.secret-card .table-container {
+  max-height: 320px;
 }
 
 .secret-header {
@@ -184,62 +30,19 @@
   gap: 0.75rem;
 }
 
-.table-container {
-  max-height: 320px;
-  overflow: auto;
-}
-
-table {
+.secret-card table {
   width: 100%;
   border-collapse: collapse;
 }
 
-th,
-td {
+.secret-card th,
+.secret-card td {
   padding: 0.75rem;
   text-align: left;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
 }
 
-th {
+.secret-card th {
   font-weight: 600;
+  color: #1f2a44;
 }
-
-@media (max-width: 960px) {
-  .control-card {
-    .control-toolbar {
-      flex-direction: column;
-      align-items: stretch;
-    }
-
-    .toolbar-filters {
-      justify-content: flex-start;
-    }
-  }
-}
-
-@media (max-width: 600px) {
-  .control-card {
-    padding: 1.5rem;
-
-    .tab-row {
-      flex-direction: column;
-      align-items: stretch;
-    }
-
-    .tab-group {
-      width: 100%;
-    }
-
-    .tab-button,
-    .mapping-button {
-      width: 100%;
-      text-align: center;
-    }
-
-    .selector {
-      flex: 1 1 100%;
-    }
-  }
-}
-

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -13,3 +13,232 @@ body {
 a {
   color: inherit;
 }
+
+:root {
+  --app-card-radius: 1.25rem;
+  --app-card-shadow: 0 24px 60px -28px rgba(15, 23, 42, 0.55);
+  --app-toolbar-gradient: linear-gradient(135deg, #f3f6ff 0%, #fdf6ff 55%, #f6fbff 100%);
+  --app-text-color: #0f172a;
+  --app-muted-text: rgba(30, 41, 59, 0.6);
+}
+
+app-home-page {
+  display: block;
+  padding: 1.5rem 0;
+}
+
+.app-shell {
+  display: grid;
+  gap: 1.75rem;
+}
+
+.material-card {
+  border-radius: var(--app-card-radius);
+  box-shadow: var(--app-card-shadow);
+  border: none;
+  background-color: rgba(255, 255, 255, 0.92);
+  color: var(--app-text-color);
+}
+
+.control-card {
+  padding: 1.75rem clamp(1.5rem, 2.5vw, 2.25rem);
+  background: var(--app-toolbar-gradient);
+
+  .control-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1.5rem;
+  }
+
+  .toolbar-left {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+  }
+
+  .toolbar-title {
+    margin: 0;
+    font-size: clamp(1.5rem, 1.5vw + 1rem, 2rem);
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    color: #1e293b;
+  }
+
+  .tab-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  .tab-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  .tab-button {
+    padding: 0.45rem 1.6rem;
+    border-radius: 999px;
+    border: 1px solid rgba(30, 64, 175, 0.18);
+    background-color: rgba(59, 130, 246, 0.12);
+    color: #1d4ed8;
+    font-weight: 600;
+    font-size: 0.95rem;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
+    transition: all 0.25s ease;
+    cursor: pointer;
+  }
+
+  .tab-button:hover,
+  .tab-button:focus-visible {
+    outline: none;
+    border-color: rgba(59, 130, 246, 0.5);
+    box-shadow: 0 8px 18px -12px rgba(37, 99, 235, 0.75);
+  }
+
+  .tab-button--active {
+    background: linear-gradient(135deg, #2563eb 0%, #60a5fa 100%);
+    color: #ffffff;
+    border-color: transparent;
+    box-shadow: 0 16px 30px -18px rgba(37, 99, 235, 0.9);
+  }
+
+  .mapping-button {
+    padding: 0.45rem 1.4rem;
+    border-radius: 999px;
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    background: rgba(255, 255, 255, 0.85);
+    color: var(--app-text-color);
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    box-shadow: 0 12px 24px -18px rgba(15, 23, 42, 0.4);
+    transition: all 0.25s ease;
+    cursor: pointer;
+  }
+
+  .mapping-button:hover,
+  .mapping-button:focus-visible {
+    outline: none;
+    border-color: rgba(59, 130, 246, 0.45);
+    color: #1d4ed8;
+  }
+
+  .toolbar-filters {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  .selector {
+    min-width: 150px;
+  }
+}
+
+.selector.mat-mdc-form-field,
+.filter-field.mat-mdc-form-field {
+  --mdc-filled-text-field-container-color: rgba(255, 255, 255, 0.82);
+  --mdc-filled-text-field-hover-container-color: rgba(255, 255, 255, 0.94);
+  --mdc-filled-text-field-focus-active-indicator-color: transparent;
+  --mdc-filled-text-field-active-indicator-color: transparent;
+  --mat-mdc-form-field-state-layer-color: transparent;
+  border-radius: 999px;
+}
+
+.selector,
+.filter-field {
+  .mdc-text-field--filled {
+    border-radius: 999px;
+    box-shadow: 0 14px 34px -22px rgba(15, 23, 42, 0.65);
+  }
+
+  .mat-mdc-form-field-infix {
+    padding: 0.6rem 1.25rem 0.55rem 1.25rem;
+  }
+
+  .mdc-line-ripple {
+    display: none;
+  }
+
+  .mdc-floating-label {
+    color: var(--app-muted-text);
+    font-weight: 500;
+  }
+
+  .mat-mdc-select-value-text,
+  .mat-mdc-select-arrow {
+    color: var(--app-text-color);
+    font-weight: 600;
+  }
+
+  .mat-mdc-select-trigger {
+    gap: 0.75rem;
+  }
+}
+
+.view-container {
+  min-height: 320px;
+}
+
+.table-container {
+  overflow: auto;
+}
+
+.table-container table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table-container th,
+.table-container td {
+  padding: 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.table-container th {
+  font-weight: 600;
+  color: #1f2a44;
+}
+
+@media (max-width: 960px) {
+  .control-card {
+    .control-toolbar {
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    .toolbar-filters {
+      justify-content: flex-start;
+    }
+  }
+}
+
+@media (max-width: 600px) {
+  .control-card {
+    padding: 1.5rem;
+
+    .tab-row {
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    .tab-group {
+      width: 100%;
+    }
+
+    .tab-button,
+    .mapping-button {
+      width: 100%;
+      text-align: center;
+    }
+
+    .selector {
+      flex: 1 1 100%;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- restyle the customer list view with segmented controls, richer filters, and improved table presentation
- move reusable shell, card, and form field styles from the home page component into the global stylesheet
- streamline the home page component stylesheet to only keep modal-specific rules

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68d6891ef338832fa1777fc8547ba160