### PR TITLE
Add modal details for bidding reports and simplify toolbar styling

### DIFF
--- a/src/app/core/services/api.service.ts
+++ b/src/app/core/services/api.service.ts
@@ -11,5 +11,9 @@ export class ApiEndpointService {
   getBiddingReports(): Observable<BiddingReport[]> {
     return this.api.get<BiddingReport[]>('/BiddingReports');
   }
+
+  getBiddingReport(reportId: number): Observable<BiddingReport> {
+    return this.api.get<BiddingReport>(`/BiddingReports/${reportId}`);
+  }
 }
 

--- a/src/app/features/home/home.module.ts
+++ b/src/app/features/home/home.module.ts
@@ -7,6 +7,7 @@ import { CustomerListComponent } from './customer-list/customer-list.component';
 import { HomeRoutingModule } from './home-routing.module';
 import { HomePageComponent } from './home-page/home-page.component';
 import { ReportsComponent } from './reports/reports.component';
+import { ReportDetailsDialogComponent } from './reports/report-details-dialog/report-details-dialog.component';
 import { HomeFiltersService } from './services/home-filters.service';
 import { TenderAwardsComponent } from './tender-awards/tender-awards.component';
 import { TenderStatusDialogComponent } from './tender-awards/status-change-dialog/tender-status-dialog.component';
@@ -15,6 +16,7 @@ import { TenderStatusDialogComponent } from './tender-awards/status-change-dialo
   declarations: [
     HomePageComponent,
     ReportsComponent,
+    ReportDetailsDialogComponent,
     CustomerListComponent,
     TenderAwardsComponent,
     TenderStatusDialogComponent

--- a/src/app/features/home/reports/bidding-report.interface.ts
+++ b/src/app/features/home/reports/bidding-report.interface.ts
@@ -10,6 +10,7 @@ export interface BiddingReport {
   weightedAvgButanePrice: number | null;
   weightedAvgPropanePrice: number | null;
   weightedTotalPrice: number | null;
+  biddingHistoryAnalysis: string | null;
   previousReportLink: string | null;
   filePath: string;
   fileName: string;

--- a/src/app/features/home/reports/report-details-dialog/report-details-dialog.component.html
+++ b/src/app/features/home/reports/report-details-dialog/report-details-dialog.component.html
@@ -1,0 +1,82 @@
+<h2 mat-dialog-title>{{ report.reportName }}</h2>
+
+<mat-dialog-content class="report-dialog-content">
+  <section class="report-meta">
+    <div class="meta-item">
+      <span class="meta-label">Status</span>
+      <span class="meta-value">{{ report.status }}</span>
+    </div>
+    <div class="meta-item">
+      <span class="meta-label">Month</span>
+      <span class="meta-value">{{ monthLabel }}</span>
+    </div>
+    <div class="meta-item">
+      <span class="meta-label">Year</span>
+      <span class="meta-value">{{ report.reportYear }}</span>
+    </div>
+    <div class="meta-item">
+      <span class="meta-label">Report Date</span>
+      <span class="meta-value">{{ formattedReportDate }}</span>
+    </div>
+  </section>
+
+  <section class="report-details">
+    <h3>Summary</h3>
+    <div class="detail-grid">
+      <div class="detail-item">
+        <span class="detail-label">Total Volume</span>
+        <span class="detail-value">{{ report.totalVolume | number: '1.0-0' }}</span>
+      </div>
+      <div class="detail-item">
+        <span class="detail-label">Propane Volume</span>
+        <span class="detail-value">{{ report.totalPropaneVolume | number: '1.0-0' }}</span>
+      </div>
+      <div class="detail-item">
+        <span class="detail-label">Butane Volume</span>
+        <span class="detail-value">{{ report.totalButaneVolume | number: '1.0-0' }}</span>
+      </div>
+      <div class="detail-item">
+        <span class="detail-label">Weighted Avg Propane Price</span>
+        <span class="detail-value">{{ report.weightedAvgPropanePrice | number: '1.2-2' }}</span>
+      </div>
+      <div class="detail-item">
+        <span class="detail-label">Weighted Avg Butane Price</span>
+        <span class="detail-value">{{ report.weightedAvgButanePrice | number: '1.2-2' }}</span>
+      </div>
+      <div class="detail-item" *ngIf="report.weightedTotalPrice !== null">
+        <span class="detail-label">Weighted Total Price</span>
+        <span class="detail-value">{{ report.weightedTotalPrice | number: '1.2-2' }}</span>
+      </div>
+    </div>
+  </section>
+
+  <section class="report-links">
+    <a
+      mat-stroked-button
+      color="primary"
+      [href]="report.filePath"
+      target="_blank"
+      rel="noopener"
+    >
+      Download {{ report.fileName }}
+    </a>
+    <a
+      *ngIf="report.previousReportLink"
+      mat-button
+      [href]="report.previousReportLink"
+      target="_blank"
+      rel="noopener"
+    >
+      View Previous Report
+    </a>
+  </section>
+
+  <section *ngIf="report.biddingHistoryAnalysis" class="report-analysis">
+    <h3>Bidding History Analysis</h3>
+    <p>{{ report.biddingHistoryAnalysis }}</p>
+  </section>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-button mat-dialog-close>Close</button>
+</mat-dialog-actions>

--- a/src/app/features/home/reports/report-details-dialog/report-details-dialog.component.scss
+++ b/src/app/features/home/reports/report-details-dialog/report-details-dialog.component.scss
@@ -1,0 +1,97 @@
+:host {
+  display: block;
+}
+
+h2[mat-dialog-title] {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.report-dialog-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding-top: 0.5rem;
+}
+
+.report-meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+}
+
+.meta-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  background-color: rgba(148, 163, 184, 0.12);
+}
+
+.meta-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.meta-value {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.report-details h3,
+.report-analysis h3 {
+  margin: 0 0 0.75rem;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.detail-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  background-color: rgba(226, 232, 240, 0.5);
+}
+
+.detail-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.detail-value {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.report-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.report-analysis p {
+  margin: 0;
+  line-height: 1.6;
+  color: rgba(15, 23, 42, 0.85);
+}
+
+:host ::ng-deep .mat-mdc-dialog-surface {
+  border-radius: 1rem;
+}

--- a/src/app/features/home/reports/report-details-dialog/report-details-dialog.component.ts
+++ b/src/app/features/home/reports/report-details-dialog/report-details-dialog.component.ts
@@ -1,0 +1,42 @@
+import { ChangeDetectionStrategy, Component, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+
+import { BiddingReport } from '../bidding-report.interface';
+
+@Component({
+  selector: 'app-report-details-dialog',
+  templateUrl: './report-details-dialog.component.html',
+  styleUrls: ['./report-details-dialog.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class ReportDetailsDialogComponent {
+  private static readonly MONTH_NAMES = [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December'
+  ] as const;
+
+  constructor(@Inject(MAT_DIALOG_DATA) public readonly report: BiddingReport) {}
+
+  get formattedReportDate(): string {
+    return this.report.reportDate ? new Date(this.report.reportDate).toLocaleDateString() : '';
+  }
+
+  get monthLabel(): string {
+    const monthNumber = Number(this.report.reportMonth);
+    if (!Number.isFinite(monthNumber) || monthNumber < 1 || monthNumber > 12) {
+      return this.report.reportMonth;
+    }
+
+    return ReportDetailsDialogComponent.MONTH_NAMES[monthNumber - 1] ?? this.report.reportMonth;
+  }
+}

--- a/src/app/features/home/reports/reports.component.html
+++ b/src/app/features/home/reports/reports.component.html
@@ -25,7 +25,11 @@
         </tr>
       </thead>
       <tbody *ngIf="reports$ | async as reports; else emptyState">
-        <tr *ngFor="let row of reports; trackBy: trackByReportId">
+        <tr
+          *ngFor="let row of reports; trackBy: trackByReportId"
+          class="reports-row"
+          (click)="openReportDetails(row)"
+        >
           <td data-label="Report Name">
             <a
               mat-button
@@ -33,6 +37,7 @@
               [href]="row.reportLink"
               target="_blank"
               rel="noopener"
+              (click)="$event.stopPropagation()"
             >
               {{ row.name }}
             </a>
@@ -54,6 +59,7 @@
                   [href]="file"
                   target="_blank"
                   rel="noopener"
+                  (click)="$event.stopPropagation()"
                 >
                   History {{ i + 1 }}
                 </a>
@@ -72,6 +78,7 @@
                 target="_blank"
                 rel="noopener"
                 [attr.aria-label]="'Download ' + row.reportFile"
+                (click)="$event.stopPropagation()"
               >
                 <mat-icon>file_download</mat-icon>
               </a>
@@ -82,6 +89,7 @@
                 target="_blank"
                 rel="noopener"
                 [attr.aria-label]="'Preview ' + row.reportFile"
+                (click)="$event.stopPropagation()"
               >
                 <mat-icon>description</mat-icon>
               </a>
@@ -97,6 +105,7 @@
               class="lock-button"
               [class.lock-button--locked]="row.locked"
               [attr.aria-label]="row.locked ? 'Unlock report' : 'Lock report'"
+              (click)="$event.stopPropagation()"
             >
               <mat-icon>{{ row.locked ? 'lock' : 'lock_open' }}</mat-icon>
             </button>
@@ -107,7 +116,13 @@
             </span>
           </td>
           <td data-label="Delete">
-            <button mat-icon-button type="button" class="delete-button" aria-label="Delete report">
+            <button
+              mat-icon-button
+              type="button"
+              class="delete-button"
+              aria-label="Delete report"
+              (click)="$event.stopPropagation()"
+            >
               <mat-icon>delete_outline</mat-icon>
             </button>
           </td>

--- a/src/app/features/home/reports/reports.component.scss
+++ b/src/app/features/home/reports/reports.component.scss
@@ -51,6 +51,10 @@
   background: rgba(226, 232, 255, 0.35);
 }
 
+.reports-row {
+  cursor: pointer;
+}
+
 .header-cell {
   display: inline-flex;
   align-items: center;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -17,7 +17,7 @@ a {
 :root {
   --app-card-radius: 1.25rem;
   --app-card-shadow: 0 24px 60px -28px rgba(15, 23, 42, 0.55);
-  --app-toolbar-gradient: linear-gradient(135deg, #f3f6ff 0%, #fdf6ff 55%, #f6fbff 100%);
+  --app-toolbar-background: #f8fafc;
   --app-text-color: #0f172a;
   --app-muted-text: rgba(30, 41, 59, 0.6);
 }
@@ -42,7 +42,7 @@ app-home-page {
 
 .control-card {
   padding: 1.75rem clamp(1.5rem, 2.5vw, 2.25rem);
-  background: var(--app-toolbar-gradient);
+  background-color: var(--app-toolbar-background);
 
   .control-toolbar {
     display: flex;
@@ -83,11 +83,10 @@ app-home-page {
     padding: 0.45rem 1.6rem;
     border-radius: 999px;
     border: 1px solid rgba(30, 64, 175, 0.18);
-    background-color: rgba(59, 130, 246, 0.12);
+    background-color: #e0ecff;
     color: #1d4ed8;
     font-weight: 600;
     font-size: 0.95rem;
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
     transition: all 0.25s ease;
     cursor: pointer;
   }
@@ -96,14 +95,14 @@ app-home-page {
   .tab-button:focus-visible {
     outline: none;
     border-color: rgba(59, 130, 246, 0.5);
-    box-shadow: 0 8px 18px -12px rgba(37, 99, 235, 0.75);
+    box-shadow: 0 8px 18px -12px rgba(37, 99, 235, 0.45);
   }
 
   .tab-button--active {
     background-color: #2563eb;
     color: #ffffff;
     border-color: transparent;
-    box-shadow: 0 16px 30px -18px rgba(37, 99, 235, 0.9);
+    box-shadow: 0 12px 24px -18px rgba(37, 99, 235, 0.55);
   }
 
   .mapping-button {


### PR DESCRIPTION
## Summary
- add an API endpoint for fetching individual bidding reports and trigger it when a table row is clicked
- present the fetched report data in a large material dialog with links to the current and previous reports
- remove gradient styling from the home toolbar tabs and background for a flatter appearance

## Testing
- npm run build *(fails: Angular style budget warnings in existing SCSS files)*

------
https://chatgpt.com/codex/tasks/task_e_68e333905504832fbbd3ebfae53d2f72