### PR TITLE
feat: filter bidding reports by selected month and year

### DIFF
--- a/src/app/core/services/api.service.ts
+++ b/src/app/core/services/api.service.ts
@@ -8,7 +8,19 @@ import { ApiService } from './api.base';
 export class ApiEndpointService {
   constructor(private readonly api: ApiService) {}
 
-  getBiddingReports(): Observable<BiddingReport[]> {
+  getBiddingReports(filters?: { month?: number | null; year?: number | null }): Observable<BiddingReport[]> {
+    const month = filters?.month ?? null;
+    const year = filters?.year ?? null;
+
+    if (month !== null && year !== null) {
+      const params = new URLSearchParams({
+        month: String(month),
+        year: String(year)
+      });
+
+      return this.api.get<BiddingReport[]>(`/BiddingReports/by-month?${params.toString()}`);
+    }
+
     return this.api.get<BiddingReport[]>('/BiddingReports');
   }
 


### PR DESCRIPTION
## Summary
- update the reports view to request bidding reports with the selected month and year when filters are applied
- add graceful fallbacks so the base report endpoint is used when filters represent "all" or are unset
- extend the API endpoint service to build the new by-month request

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e33ab2018c832fa44dad0212c3ac82