### PR TITLE
Integrate CAL authorization

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@angular/platform-browser": "^18.2.0",
     "@angular/platform-browser-dynamic": "^18.2.0",
     "@angular/router": "^18.2.0",
+    "@cvx/cal-angular": "^5.0.0",
     "axios": "^1.12.2",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -4,6 +4,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { AppComponent } from './app.component';
 import { CoreModule } from './core/core.module';
+import { CalAuthService } from './core/services/cal-auth.service';
 
 describe('AppComponent', () => {
   let fixture: ComponentFixture<AppComponent>;
@@ -11,7 +12,13 @@ describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [RouterTestingModule, CoreModule],
-      declarations: [AppComponent]
+      declarations: [AppComponent],
+      providers: [
+        {
+          provide: CalAuthService,
+          useValue: { initialize: jasmine.createSpy('initialize') }
+        }
+      ]
     }).compileComponents();
 
     fixture = TestBed.createComponent(AppComponent);

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,8 +1,15 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { CalAuthService } from './core/services/cal-auth.service';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss'
 })
-export class AppComponent {}
+export class AppComponent implements OnInit {
+  constructor(private readonly calAuthService: CalAuthService) {}
+
+  ngOnInit(): void {
+    this.calAuthService.initialize();
+  }
+}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,5 +1,7 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
+import { HttpClientModule } from '@angular/common/http';
+import { CalAngularModule } from '@cvx/cal-angular';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -8,7 +10,13 @@ import { CoreModule } from './core/core.module';
 
 @NgModule({
   declarations: [AppComponent],
-  imports: [BrowserModule, AppRoutingModule, CoreModule],
+  imports: [
+    BrowserModule,
+    HttpClientModule,
+    CalAngularModule.forRoot('assets/config.json'),
+    AppRoutingModule,
+    CoreModule
+  ],
   providers: [provideAnimationsAsync()],
   bootstrap: [AppComponent]
 })

--- a/src/app/core/services/api.base.ts
+++ b/src/app/core/services/api.base.ts
@@ -1,4 +1,5 @@
 import { Inject, Injectable, InjectionToken, Optional } from '@angular/core';
+import { CalAngularService, ConfigService } from '@cvx/cal-angular';
 import axios, {
   AxiosInstance,
   AxiosRequestConfig,
@@ -17,13 +18,30 @@ type RequestConfig = AxiosRequestConfig;
 export class ApiService {
   private readonly client: AxiosInstance;
 
-  constructor(@Optional() @Inject(API_BASE_URL) baseUrl?: string) {
+  constructor(
+    @Optional() @Inject(API_BASE_URL) baseUrl: string | undefined,
+    private readonly calAngularService: CalAngularService,
+    private readonly configService: ConfigService
+  ) {
     this.client = axios.create({
       baseURL: baseUrl ?? DEFAULT_API_BASE_URL,
       headers: {
         'Content-Type': 'application/json'
       }
     });
+
+    this.client.interceptors.request.use(
+      async (config) => {
+        const token = await this.acquireAccessToken();
+
+        if (token) {
+          this.attachAuthorizationHeader(config as InternalAxiosRequestConfig, token);
+        }
+
+        return config;
+      },
+      (error) => Promise.reject(error)
+    );
 
     this.client.interceptors.response.use(
       (response) => response,
@@ -57,6 +75,72 @@ export class ApiService {
         .request<T>(config as InternalAxiosRequestConfig)
         .then((response: AxiosResponse<T>) => response.data)
     );
+  }
+
+  private attachAuthorizationHeader(config: InternalAxiosRequestConfig, token: string): void {
+    const headerValue = `Bearer ${token}`;
+
+    const headerContainer = config.headers as { set?: (name: string, value: string) => void } & Record<string, unknown>;
+
+    if (typeof headerContainer?.set === 'function') {
+      headerContainer.set('Authorization', headerValue);
+      return;
+    }
+
+    config.headers = {
+      ...(config.headers ?? {}),
+      Authorization: headerValue
+    } as Record<string, unknown>;
+  }
+
+  private async acquireAccessToken(): Promise<string | undefined> {
+    const scopes = this.resolveScopes();
+
+    const service = this.calAngularService as unknown as {
+      acquireToken?: (scopes?: string[]) => Promise<string | undefined>;
+      getAccessToken?: (scopes?: string[]) => Promise<string | undefined>;
+      getToken?: (scopes?: string[]) => Promise<string | undefined>;
+    };
+
+    const acquisitionStrategies: Array<keyof typeof service> = ['acquireToken', 'getAccessToken', 'getToken'];
+
+    for (const strategy of acquisitionStrategies) {
+      const fn = service[strategy];
+
+      if (typeof fn !== 'function') {
+        continue;
+      }
+
+      try {
+        const token = await fn.call(service, scopes);
+
+        if (token) {
+          return token;
+        }
+      } catch (error) {
+        console.error(`CAL token acquisition using "${strategy}" failed.`, error);
+      }
+    }
+
+    return undefined;
+  }
+
+  private resolveScopes(): string[] {
+    const aggregatedScopes: string[] = [];
+    const scopeCandidates = [
+      this.configService.getSettings<string[]>('graphScopes'),
+      this.configService.getSettings<string[]>('oidcScopes')
+    ];
+
+    for (const candidate of scopeCandidates) {
+      if (Array.isArray(candidate)) {
+        aggregatedScopes.push(
+          ...candidate.filter((scope): scope is string => typeof scope === 'string' && scope.length > 0)
+        );
+      }
+    }
+
+    return Array.from(new Set(aggregatedScopes));
   }
 
   private normalizeError(error: unknown): Error {

--- a/src/app/core/services/cal-auth.service.ts
+++ b/src/app/core/services/cal-auth.service.ts
@@ -1,0 +1,63 @@
+import { Injectable } from '@angular/core';
+import { CalAngularService, ConfigService } from '@cvx/cal-angular';
+import { EMPTY, Observable, catchError, filter, switchMap, take, tap } from 'rxjs';
+
+import { ApiService } from './api.base';
+
+@Injectable({ providedIn: 'root' })
+export class CalAuthService {
+  private initialized = false;
+
+  constructor(
+    private readonly calAngularService: CalAngularService,
+    private readonly configService: ConfigService,
+    private readonly apiService: ApiService
+  ) {}
+
+  initialize(): void {
+    if (this.initialized) {
+      return;
+    }
+
+    this.initialized = true;
+
+    this.calAngularService
+      .isUserSignedIn()
+      .pipe(
+        tap((isSignedIn) => {
+          if (!isSignedIn) {
+            this.triggerInteractiveSignIn();
+          }
+        }),
+        filter(Boolean),
+        take(1),
+        switchMap(() => this.authenticateWithBackend()),
+        catchError((error) => {
+          console.error('Failed to establish CAL authentication session.', error);
+          return EMPTY;
+        })
+      )
+      .subscribe();
+  }
+
+  private triggerInteractiveSignIn(): void {
+    const autoSignIn = this.configService.getSettings<boolean>('autoSignIn');
+
+    if (autoSignIn) {
+      // auto sign-in is handled by CAL configuration
+      return;
+    }
+
+    const interactiveService = this.calAngularService as unknown as {
+      signIn?: () => Promise<unknown>;
+      login?: () => Promise<unknown>;
+      loginPopup?: () => Promise<unknown>;
+    };
+
+    void (interactiveService.signIn?.() ?? interactiveService.login?.() ?? interactiveService.loginPopup?.());
+  }
+
+  private authenticateWithBackend(): Observable<void> {
+    return this.apiService.post<void>('/auth');
+  }
+}

--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -1,0 +1,19 @@
+{
+  "autoSignIn": true,
+  "popupForLogin": true,
+  "cacheLocation": "localStorage",
+  "instance": "https://login.microsoftonline.com/",
+  "tenantId": "fd799da1-bfc1-4234-a91c-72b3a1cb9e26",
+  "clientId": "",
+  "redirectUri": "http://localhost:4200",
+  "oidcScopes": [
+    "openid",
+    "profile",
+    "offline_access",
+    "User.Read"
+  ],
+  "graphScopes": [
+    "User.Read",
+    "User.Read.All"
+  ]
+}

--- a/src/types/cvx-cal-angular.d.ts
+++ b/src/types/cvx-cal-angular.d.ts
@@ -1,0 +1,17 @@
+declare module '@cvx/cal-angular' {
+  import { ModuleWithProviders } from '@angular/core';
+  import { Observable } from 'rxjs';
+
+  export class CalAngularModule {
+    static forRoot(configPath: string): ModuleWithProviders<CalAngularModule>;
+  }
+
+  export class CalAngularService {
+    isUserSignedIn(): Observable<boolean>;
+    getAccount<TAccount = { username?: string } | null>(): TAccount | null;
+  }
+
+  export class ConfigService {
+    getSettings<T = unknown>(key: string): T;
+  }
+}


### PR DESCRIPTION
## Summary
- add the CAL configuration asset and wire CalAngularModule into the root module
- introduce a CalAuthService that drives background sign-in and calls the `/auth` API during app init
- augment the Axios API client to request CAL tokens and attach Authorization headers, plus add supporting typings and test stubs

## Testing
- not run (private @cvx/cal-angular package is unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e49f27fbe4832fadd84f563fb8cef6