### PR TITLE
feat: integrate CAL AAD token acquisition

### DIFF
--- a/src/app/core/services/api.base.ts
+++ b/src/app/core/services/api.base.ts
@@ -1,18 +1,24 @@
 import { Inject, Injectable, InjectionToken, Optional } from '@angular/core';
 import { CalAngularService, ConfigService } from '@cvx/cal-angular';
+import type { AuthenticationResult } from '@azure/msal-browser';
 import axios, {
   AxiosInstance,
   AxiosRequestConfig,
   AxiosResponse,
   InternalAxiosRequestConfig
 } from 'axios';
-import { from, Observable } from 'rxjs';
+import { firstValueFrom, from, isObservable, Observable } from 'rxjs';
 import { environment } from '../../../environments/environment';
 
 export const API_BASE_URL = new InjectionToken<string>('API_BASE_URL');
 const DEFAULT_API_BASE_URL = environment.apiBaseUrl;
 
 type RequestConfig = AxiosRequestConfig;
+type AadTokenResult = string | AuthenticationResult | null | undefined;
+type AadTokenResultSource =
+  | Promise<AadTokenResult>
+  | Observable<AadTokenResult>
+  | AadTokenResult;
 
 @Injectable({ providedIn: 'root' })
 export class ApiService {
@@ -96,6 +102,70 @@ export class ApiService {
   private async acquireAccessToken(): Promise<string | undefined> {
     const scopes = this.resolveScopes();
 
+    const token = await this.acquireTokenViaGetAADToken(scopes);
+
+    if (token) {
+      return token;
+    }
+
+    return this.acquireTokenViaLegacyStrategies(scopes);
+  }
+
+  private async acquireTokenViaGetAADToken(scopes: string[]): Promise<string | undefined> {
+    const service = this.calAngularService as unknown as {
+      getAADToken?: (scopes?: string[]) => AadTokenResultSource;
+    };
+
+    const getAADToken = service.getAADToken;
+
+    if (typeof getAADToken !== 'function') {
+      return undefined;
+    }
+
+    try {
+      const result = getAADToken.call(
+        service,
+        scopes.length > 0 ? scopes : undefined
+      );
+
+      const resolved = await this.resolveTokenResult(result);
+
+      return this.normalizeAccessToken(resolved);
+    } catch (error) {
+      console.error('CAL token acquisition using "getAADToken" failed.', error);
+      return undefined;
+    }
+  }
+
+  private async resolveTokenResult(result: AadTokenResultSource): Promise<AadTokenResult> {
+    if (isObservable(result)) {
+      return firstValueFrom(result);
+    }
+
+    if (result && typeof (result as PromiseLike<unknown>).then === 'function') {
+      return result as Promise<AadTokenResult>;
+    }
+
+    return result as AadTokenResult;
+  }
+
+  private normalizeAccessToken(token: AadTokenResult): string | undefined {
+    if (typeof token === 'string' && token.trim().length > 0) {
+      return token;
+    }
+
+    if (token && typeof token === 'object' && 'accessToken' in token) {
+      const accessToken = (token as AuthenticationResult).accessToken;
+
+      if (typeof accessToken === 'string' && accessToken.trim().length > 0) {
+        return accessToken;
+      }
+    }
+
+    return undefined;
+  }
+
+  private async acquireTokenViaLegacyStrategies(scopes: string[]): Promise<string | undefined> {
     const service = this.calAngularService as unknown as {
       acquireToken?: (scopes?: string[]) => Promise<string | undefined>;
       getAccessToken?: (scopes?: string[]) => Promise<string | undefined>;
@@ -112,7 +182,7 @@ export class ApiService {
       }
 
       try {
-        const token = await fn.call(service, scopes);
+        const token = await fn.call(service, scopes.length > 0 ? scopes : undefined);
 
         if (token) {
           return token;

--- a/src/types/azure-msal-browser.d.ts
+++ b/src/types/azure-msal-browser.d.ts
@@ -1,0 +1,9 @@
+declare module '@azure/msal-browser' {
+  export interface AuthenticationResult {
+    accessToken: string;
+    idToken?: string;
+    account?: unknown;
+    expiresOn?: Date | string | number | null;
+    [key: string]: unknown;
+  }
+}


### PR DESCRIPTION
## Summary
- acquire CAL access tokens using getAADToken before falling back to legacy helpers
- normalize string and AuthenticationResult responses so Axios requests receive bearer tokens
- declare a minimal AuthenticationResult interface stub for local type checking

## Testing
- npm run build *(fails in this environment because private @cvx/cal-angular and related modules cannot be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68e4a42299b8832fa709e3054dc73b5f